### PR TITLE
Fix Docker's "exec user process caused no such file or directory" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 ADD . /build
 
 RUN go get -t -v ./... && \
-    go build -o azure-blob-storage-proxy ./cmd/
+    CGO_ENABLED=0 go build -o azure-blob-storage-proxy ./cmd/
 
 FROM alpine:latest
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/azure-blob-storage-proxy/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:latest as builder
 WORKDIR /build
 ADD . /build
 
-RUN go get -t -v ./... && \
-    CGO_ENABLED=0 go build -o azure-blob-storage-proxy ./cmd/
+RUN CGO_ENABLED=0 go build -o azure-blob-storage-proxy ./cmd/
 
 FROM alpine:latest
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/azure-blob-storage-proxy/


### PR DESCRIPTION
There's probably a mismatch between dynamic library versions in the `golang:latest` and `alpine:latest` containers. Link statically to avoid this.